### PR TITLE
memory: Fix a typo in the SwapTotal regular expression

### DIFF
--- a/delightful/widgets/memory.lua
+++ b/delightful/widgets/memory.lua
@@ -70,7 +70,7 @@ module('delightful.widgets.memory')
 -- Helper
 function is_swap_available()
     for line in io.lines('/proc/meminfo') do
-        local total_swap = tonumber(line:match('^SwapTotal:%s+(%d+)%s+kB4'))
+        local total_swap = tonumber(line:match('^SwapTotal:%s+(%d+)%s+kB$'))
         if total_swap and total_swap > 0 then
             return true
         end


### PR DESCRIPTION
This typo has been around for a long, long time and results in is_swap_available() always returning false.