### PR TITLE
datetime: Make clock format configurable

### DIFF
--- a/README.mdwn
+++ b/README.mdwn
@@ -244,7 +244,8 @@ Default configuration should work for most people.
 
 ## Date and time widget
 
-No configuration options available at all.
+* `clock_format'
+	* strftime() format string controlling what to display in the wibox. Not defined by default, in which case the default format of awful.textclock is used.
 
 ## IMAP widget
 

--- a/README.txt
+++ b/README.txt
@@ -259,7 +259,10 @@ CPU widget
 
 Date and time widget
 
-   No configuration options available at all.
+     * clock_format
+          + strftime() format string controlling what to display in the
+	    wibox. Not defined by default, in which case the default
+	    format of awful.textclock is used.
 
 IMAP widget
 

--- a/delightful/widgets/datetime.lua
+++ b/delightful/widgets/datetime.lua
@@ -15,6 +15,17 @@
 -- http://awesome.naquadah.org/wiki/Calendar_widget#Module_for_3.4
 --
 --
+-- Configuration:
+--
+-- The load() function can be supplied with configuration.
+-- Format of the configuration is as follows.
+-- {
+-- -- Date/time format string passed to awful.textclock. Empty by default,
+-- -- in which case the default format of the latter is used.
+--           clock_format = ' %R ',
+-- }
+--
+--
 -- Theme:
 --
 -- The widget uses following colors if available in the Awesome theme.
@@ -27,14 +38,53 @@
 local awful     = require('awful')
 local beautiful = require('beautiful')
 
+local delightful = { utils = require('delightful.utils') }
+
 local calendar2 = require('calendar2')
 
 local string = { format = string.format }
 
 module('delightful.widgets.datetime')
 
-function load()
-    local widget = awful.widget.textclock()
+local datetime_config
+local fatal_error
+
+local config_description = {
+    {
+        name = 'clock_format',
+        validate = function(value) return delightful.utils.config_string(value) end
+    },
+}
+
+-- Configuration handler
+function handle_config(user_config)
+    local empty_config = delightful.utils.get_empty_config(config_description)
+    if not user_config then
+        user_config = empty_config
+    end
+    local config_data = delightful.utils.normalize_config(user_config, config_description)
+    local validation_errors = delightful.utils.validate_config(config_data, config_description)
+    if validation_errors then
+        fatal_error = 'Configuration errors: \n'
+        for error_index, error_entry in pairs(validation_errors) do
+            fatal_error = string.format('%s %s', fatal_error, error_entry)
+            if error_index < #validation_errors then
+                fatal_error = string.format('%s \n', fatal_error)
+            end
+        end
+        datetime_config = empty_config
+        return
+    end
+    datetime_config = config_data
+end
+
+function load(self, config)
+    handle_config(config)
+    if fatal_error then
+        delightful.utils.print_error('datetime', fatal_error)
+	return nil, nil
+    end
+    local widget = awful.widget.textclock(datetime_config.clock_format)
     local calendar_format = '%s'
     if beautiful.fg_focus and beautiful.bg_focus then
         calendar_format = string.format('<span color="%s" background="%s">%%s</span>',


### PR DESCRIPTION
The Date and Time widget internally uses awful.textclock() and the latter can be configured simply by passing it an strftime() format string as an argument. Therefore, this has mostly been the matter of defining a configuration option allowing the user to customise this string.